### PR TITLE
Fix generate.yml workflow name

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,4 +1,4 @@
-name: Update intermediates collection
+name: Update roots collection
 on:
   # NOTE: Omit automatic tagging for pushes.
   # push:


### PR DESCRIPTION
Replace `interemdiates` with `roots` as intended.